### PR TITLE
Update spelling typo in oxford_comma_spec.rb

### DIFF
--- a/spec/oxford_comma_spec.rb
+++ b/spec/oxford_comma_spec.rb
@@ -1,5 +1,5 @@
 describe "#oxford_comma" do
-  it 'returns a string without any additional fomatting when given a 1-element array' do
+  it 'returns a string without any additional formatting when given a 1-element array' do
     expect(oxford_comma(["kiwi"])).to eq("kiwi")
   end
   it "adds 'and' between elements when given a 2-element array" do


### PR DESCRIPTION
"formatting" is misspelled in the lab tests section.
> 
> "#oxford_comma
> returns a string without any additional **fomatting** when given a 1-element array"